### PR TITLE
Viewer filter fixups

### DIFF
--- a/src/tc-renderer/ng/elements/chatters/chatters.css
+++ b/src/tc-renderer/ng/elements/chatters/chatters.css
@@ -31,3 +31,14 @@ chatters .chatter {
 chatters .chatter:hover {
   text-decoration: underline;
 }
+
+chatters input {
+  border: none;
+  outline: none;
+  cursor: pointer;
+  margin: 5px 0;
+}
+
+chatters input:focus {
+  cursor: default;
+}

--- a/src/tc-renderer/ng/elements/chatters/chatters.html
+++ b/src/tc-renderer/ng/elements/chatters/chatters.html
@@ -1,6 +1,5 @@
 <input
   ng-model="searchText"
-  ng-focus="showViewers(true)"
   placeholder="Filter chatters - {{api.chatter_count | number}}"
   ng-show="api.chatter_count > 50"
   ng-model-options="{debounce: 300}"

--- a/src/tc-renderer/ng/elements/chatters/chatters.html
+++ b/src/tc-renderer/ng/elements/chatters/chatters.html
@@ -27,6 +27,6 @@
         Too many, show all? <i class="zmdi zmdi-expand-more"></i>
       </md-button>
     </div>
-    <div ng-if="key === 'viewers' && tooManyNotDoable()">Too Many!</div>
+    <div ng-if="key === 'viewers' && tooManyNotDoable()">Too many, try filtering</div>
   </div>
 </div>

--- a/src/tc-renderer/ng/elements/chatters/chatters.html
+++ b/src/tc-renderer/ng/elements/chatters/chatters.html
@@ -1,7 +1,10 @@
-<md-input-container class="input-container" style="padding-bottom:0;" ng-class="{disabled: !irc.ready}">
-  <label for="search">Filter Viewers</label>
-  <input type="text" id="search" ng-model="searchText" ng-focus="showViewers(true)">
-</md-input-container>
+<input
+  ng-model="searchText"
+  ng-focus="showViewers(true)"
+  placeholder="Filter chatters - {{api.chatter_count | number}}"
+  ng-show="api.chatter_count > 50"
+  ng-model-options="{debounce: 300}"
+>
 
 <div ng-repeat="(key, value) in api.chatters">
   <h3 ng-if="value.length">{{prettyChatterNames(key)}}</h3>

--- a/src/tc-renderer/ng/elements/chatters/chatters.js
+++ b/src/tc-renderer/ng/elements/chatters/chatters.js
@@ -43,10 +43,6 @@ angular.module('tc').directive('chatters', ($http, session) => {
       session.selectedUserChannel = scope.channel;
     };
 
-    scope.chatterCount = function() {
-      return
-    };
-
     async function fetchList(attemptNumber) {
       if (!isChannelSelected()) return;
       try {scope.api = await chatters(scope.channel);}
@@ -55,8 +51,6 @@ angular.module('tc').directive('chatters', ($http, session) => {
         console.warn('CHATTERS: Failed to get user list. ' + attemptNumber, e);
         if (attemptNumber < 6) fetchList(attemptNumber + 1);
       }
-
-      console.log(scope.api);
       scope.$apply();
     }
 

--- a/src/tc-renderer/ng/elements/chatters/chatters.js
+++ b/src/tc-renderer/ng/elements/chatters/chatters.js
@@ -12,6 +12,7 @@ angular.module('tc').directive('chatters', ($http, session) => {
     let forceShowViewers = false;
     let timeout = null;
     scope.api = null;
+    scope.searchText = '';
 
     fetchList();
     setInterval(fetchList, 120000);
@@ -32,12 +33,17 @@ angular.module('tc').directive('chatters', ($http, session) => {
     };
 
     scope.tooManyNotDoable = function() {
+      if (scope.searchText.length > 1) return false; // Show all if searching
       return scope.api && scope.api.chatters.viewers.length > 10000;
     };
 
     scope.selectUser = function(username) {
       session.selectedUser = username;
       session.selectedUserChannel = scope.channel;
+    };
+
+    scope.chatterCount = function() {
+      return
     };
 
     async function fetchList(attemptNumber) {
@@ -48,6 +54,8 @@ angular.module('tc').directive('chatters', ($http, session) => {
         console.warn('CHATTERS: Failed to get user list. ' + attemptNumber, e);
         if (attemptNumber < 6) fetchList(attemptNumber + 1);
       }
+
+      console.log(scope.api);
       scope.$apply();
     }
 

--- a/src/tc-renderer/ng/elements/chatters/chatters.js
+++ b/src/tc-renderer/ng/elements/chatters/chatters.js
@@ -28,6 +28,7 @@ angular.module('tc').directive('chatters', ($http, session) => {
     scope.showViewers = function(force) {
       if (typeof force === 'boolean') forceShowViewers = force;
       if (!scope.api) return false;
+      if (scope.searchText.length > 1) return true;
       if (scope.api.chatters.viewers.length < 201) return true;
       else return forceShowViewers;
     };


### PR DESCRIPTION
- Only show the filter if there are more than 50 chatters
- Tweak design (material inputs are too bulky for this
- Allow it to work even if there are "too many" (over 10k) chatters