### PR TITLE
Add a "check for updates" button to the options page

### DIFF
--- a/src/tc-renderer/app.css
+++ b/src/tc-renderer/app.css
@@ -76,7 +76,8 @@ md-sidenav.collapsed {
 }
 
 md-toast {
-  bottom: 45px !important;
+  left: unset !important;
+  right: 8px !important;
 }
 
 .lighter {

--- a/src/tc-renderer/lib/auto-updater.js
+++ b/src/tc-renderer/lib/auto-updater.js
@@ -21,7 +21,22 @@ else {
 
   function check() {
     console.log('Checking for updates at ' + url);
+    autoUpdater.on('error', handleAutomaticCheckError);
     autoUpdater.checkForUpdates();
+
+    function handleAutomaticCheckError(error) {
+      console.warn('Unable to check for updates. ' +
+        'You\'re probably running Tc ' +
+        'in standalone mode, or the server is down.', error);
+    }
+
+    function removeListener() {
+      autoUpdater.removeListener('error', handleAutomaticCheckError)
+    }
+
+    // For some reason, only one error listener works at a time, so make
+    // sure we clean up in case the UI wants to listen to this error elsewhere
+    setTimeout(removeListener, 10000);
   }
 }
 

--- a/src/tc-renderer/lib/auto-updater.js
+++ b/src/tc-renderer/lib/auto-updater.js
@@ -15,17 +15,14 @@ else {
   const url = `http://dl.gettc.xyz/update/${os}/${version}`;
 
   autoUpdater.setFeedURL(url);
-  //autoUpdater.setFeedURL('http://localhost/'); // Uncomment For testing
 
   setTimeout(check, 15000);
-  setInterval(check, 1000 * 60 * 60 * 23);
+  setInterval(check, 1000 * 60 * 60 * 23); // Check for updates every 23 hours
 
   function check() {
     console.log('Checking for updates at ' + url);
     autoUpdater.checkForUpdates();
   }
-
-  autoUpdater.on('error', (e) => console.warn('Error checking for updates.', e));
 }
 
 export default autoUpdater;

--- a/src/tc-renderer/ng/elements/settings-panel/settings-panel.css
+++ b/src/tc-renderer/ng/elements/settings-panel/settings-panel.css
@@ -49,6 +49,10 @@ settings-panel md-input-container {
   width: 300px;
 }
 
+settings-panel .tc h1 {
+  margin-bottom: 0;
+}
+
 settings-panel .shortcuts .new-shortcut-form {
   display: flex;
   flex-direction: row;

--- a/src/tc-renderer/ng/elements/settings-panel/settings-panel.html
+++ b/src/tc-renderer/ng/elements/settings-panel/settings-panel.html
@@ -7,8 +7,8 @@
     <!-- TODO refactor this awful repetition -->
 
     <md-list-item class="menu-item"
-                  ng-click="m.selected = 'about'"
-                  ng-class="{selected: m.selected === 'about'}">
+                  ng-click="m.selected = 'tc'"
+                  ng-class="{selected: m.selected === 'tc'}">
       <p>Tc</p>
     </md-list-item>
 
@@ -43,7 +43,7 @@
 
 <div flex class="settings-content" ng-switch on="m.selected" layout="column">
 
-  <md-content flex ng-switch-when="about" layout="column" class="tc"
+  <md-content flex ng-switch-when="tc" layout="column" class="tc"
               layout-align="center center">
     <img style="width: 150px;" src="../../../../assets/icon256.png">
 

--- a/src/tc-renderer/ng/elements/settings-panel/settings-panel.html
+++ b/src/tc-renderer/ng/elements/settings-panel/settings-panel.html
@@ -53,7 +53,11 @@
       <a href-external="http://gettc.xyz/">GetTc.xyz</a>
     </p>
     <p>
-      <md-button>Check for updates</md-button>
+      <md-button
+          ng-click="tc.checkForUpdates()"
+          ng-disabled="tc.checkedForUpdate">
+        Check for updates
+      </md-button>
     </p>
 
   </md-content>

--- a/src/tc-renderer/ng/elements/settings-panel/settings-panel.html
+++ b/src/tc-renderer/ng/elements/settings-panel/settings-panel.html
@@ -7,6 +7,12 @@
     <!-- TODO refactor this awful repetition -->
 
     <md-list-item class="menu-item"
+                  ng-click="m.selected = 'about'"
+                  ng-class="{selected: m.selected === 'about'}">
+      <p>About</p>
+    </md-list-item>
+
+    <md-list-item class="menu-item"
                   ng-click="m.selected = 'highlights'"
                   ng-class="{selected: m.selected === 'highlights'}">
       <p>Highlights</p>
@@ -30,11 +36,6 @@
                   ng-click="m.selected = 'ignore'"
                   ng-class="{selected: m.selected === 'ignore'}">
       <p>Ignore List</p>
-    </md-list-item>
-    <md-list-item class="menu-item"
-                  ng-click="m.selected = 'about'"
-                  ng-class="{selected: m.selected === 'about'}">
-      <p>About</p>
     </md-list-item>
   </md-list>
 

--- a/src/tc-renderer/ng/elements/settings-panel/settings-panel.html
+++ b/src/tc-renderer/ng/elements/settings-panel/settings-panel.html
@@ -9,7 +9,7 @@
     <md-list-item class="menu-item"
                   ng-click="m.selected = 'about'"
                   ng-class="{selected: m.selected === 'about'}">
-      <p>About</p>
+      <p>Tc</p>
     </md-list-item>
 
     <md-list-item class="menu-item"
@@ -42,6 +42,21 @@
 </md-sidenav>
 
 <div flex class="settings-content" ng-switch on="m.selected" layout="column">
+
+  <md-content flex ng-switch-when="about" layout="column" class="tc"
+              layout-align="center center">
+    <img style="width: 150px;" src="../../../../assets/icon256.png">
+
+    <h1 class="md-headline">Tc, the chat client for Twitch</h1>
+    <p>
+      <span>Version: {{m.version}}</span> |
+      <a href-external="http://gettc.xyz/">GetTc.xyz</a>
+    </p>
+    <p>
+      <md-button>Check for updates</md-button>
+    </p>
+
+  </md-content>
 
   <md-content ng-switch-when="highlights" class="highlights">
     <h1 class="md-headline">Highlighted phrases</h1>
@@ -228,14 +243,4 @@
     </div>
   </md-content>
 
-  <md-content flex ng-switch-when="about" layout="column"
-              layout-align="center center">
-    <img style="width: 150px;" src="../../../../assets/icon256.png">
-
-    <h1 class="md-headline">Tc, the chat client for Twitch</h1>
-    <p>
-      <span>Version: {{m.version}}</span> |
-      <a href-external="http://gettc.xyz/">GetTc.xyz</a>
-    </p>
-  </md-content>
 </div>

--- a/src/tc-renderer/ng/elements/settings-panel/settings-panel.js
+++ b/src/tc-renderer/ng/elements/settings-panel/settings-panel.js
@@ -12,7 +12,7 @@ angular.module('tc').directive('settingsPanel', (highlights, notifications) => {
     scope.settings = settings;
     scope.m = {
       version: electron.remote.app.getVersion(),
-      selected: 'highlights'
+      selected: 'about'
     };
 
     scope.highlights = {

--- a/src/tc-renderer/ng/elements/settings-panel/settings-panel.js
+++ b/src/tc-renderer/ng/elements/settings-panel/settings-panel.js
@@ -12,7 +12,7 @@ angular.module('tc').directive('settingsPanel', (highlights, notifications) => {
     scope.settings = settings;
     scope.m = {
       version: electron.remote.app.getVersion(),
-      selected: 'about'
+      selected: 'tc'
     };
 
     scope.highlights = {

--- a/src/tc-renderer/ng/elements/settings-panel/settings-panel.js
+++ b/src/tc-renderer/ng/elements/settings-panel/settings-panel.js
@@ -6,13 +6,48 @@ import settings from '../../../lib/settings/settings';
 import replacements from '../../../lib/data/replacements.json';
 import autoUpdater from '../../../lib/auto-updater';
 
-angular.module('tc').directive('settingsPanel', (highlights, notifications) => {
+angular.module('tc').directive('settingsPanel', (
+  highlights,
+  notifications,
+  $mdToast
+) => {
   function link(scope, element) {
     element.attr('layout', 'row');
     scope.settings = settings;
     scope.m = {
       version: electron.remote.app.getVersion(),
       selected: 'tc'
+    };
+
+    scope.tc = {
+      checkedForUpdate: false,
+      checkForUpdates() {
+        scope.tc.checkedForUpdate = true;
+        const a = autoUpdater;
+        a.checkForUpdates();
+        a.once('error', updateError);
+        a.once('update-available', updateAvailableToast);
+        a.once('update-not-available', updateNotAvailableToast);
+
+        scope.$on('$destroy', () => {
+          a.removeListener('error', updateError);
+          a.removeListener('update-available', updateAvailableToast);
+          a.removeListener('update-not-available', updateNotAvailableToast);
+        });
+
+        function updateError(e) {
+          $mdToast.showSimple('Unable to check for updates');
+          console.log('err', e);
+        }
+        
+        function updateNotAvailableToast() {
+          $mdToast.showSimple('No updates found');
+        }
+
+        function updateAvailableToast() {
+          $mdToast.showSimple('Update found. Downloading...');
+        }
+      }
     };
 
     scope.highlights = {
@@ -69,8 +104,6 @@ angular.module('tc').directive('settingsPanel', (highlights, notifications) => {
         if (settings.notifications.soundOnMention) notifications.playSound();
       }
     };
-
-    autoUpdater.checkForUpdates();
 
     scope.zoomLabel = () => {
       if (settings.appearance.zoom === 100) return 'Normal';

--- a/src/tc-renderer/ng/elements/settings-panel/settings-panel.js
+++ b/src/tc-renderer/ng/elements/settings-panel/settings-panel.js
@@ -24,10 +24,10 @@ angular.module('tc').directive('settingsPanel', (
       checkForUpdates() {
         scope.tc.checkedForUpdate = true;
         const a = autoUpdater;
-        a.checkForUpdates();
         a.once('error', updateError);
         a.once('update-available', updateAvailableToast);
         a.once('update-not-available', updateNotAvailableToast);
+        a.checkForUpdates();
 
         scope.$on('$destroy', () => {
           a.removeListener('error', updateError);
@@ -37,7 +37,7 @@ angular.module('tc').directive('settingsPanel', (
 
         function updateError(e) {
           $mdToast.showSimple('Unable to check for updates');
-          console.log('err', e);
+          console.warn('Update error:', e);
         }
         
         function updateNotAvailableToast() {


### PR DESCRIPTION
Tc automatically checks for updates 15 seconds after launch and every 23 hours.  

Now you can also check manually. This is important in cases where you might see a new update is available from a tweet and want to obtain it immediately.

I actually like the 23 hour window because it gives me a chance to fix potential bugs with a new release before it reaches the majority of users. 