### PR TITLE
Use word boundaries for highlight phrases, closes #334

### DIFF
--- a/src/tc-renderer/ng/providers/highlights.js
+++ b/src/tc-renderer/ng/providers/highlights.js
@@ -14,7 +14,7 @@ angular.module('tc').factory('highlights', function() {
         if (me.test(line)) return true;
       }
       return settings.highlights.some(function(highlight) {
-        var regex = new RegExp(highlight, 'i');
+        var regex = new RegExp(`\\b${highlight}\\b`, 'i');
         return regex.test(line);
       });
     },


### PR DESCRIPTION
This "breaks" existing behavior, so make sure to announce it in the release notes