### PR TITLE
Stop users from logging in unless they're using a token

### DIFF
--- a/src/tc-renderer/ng/elements/login/login.css
+++ b/src/tc-renderer/ng/elements/login/login.css
@@ -45,3 +45,7 @@ login .generate-link {
 login .password-notice {
   margin-top: 0;
 }
+
+login .password-warning {
+  color: darkred;
+}

--- a/src/tc-renderer/ng/elements/login/login.html
+++ b/src/tc-renderer/ng/elements/login/login.html
@@ -15,19 +15,25 @@
 
     <form ng-submit="login()">
       <md-input-container>
-        <label>Oauth password</label>
+        <label>Oauth token</label>
         <input ng-if="m.haveUsername" ng-model="m.password" type="password"
                auto-focus>
         <input ng-if="!m.haveUsername" ng-model="m.password" type="password">
       </md-input-container>
     </form>
 
-    <p class="password-notice">This is not your regular account password, you
-      need to generate a special "oauth:" password.</p>
-    <a class="generate-link" ng-click="generate()">Click here to generate your
-      password</a>
 
-    <md-button class="login-button md-fab md-primary" aria-label="Log in"
+    <p class="password-warning" ng-if="doesntLookLikeToken()">
+      You must use a token, not your password.
+    </p>
+    <p class="password-notice">This is not your regular account password, you
+      need to generate a special "oauth token".</p>
+    <a class="generate-link" ng-click="generate()">Click here to generate your
+      token</a>
+
+    <md-button class="login-button md-fab md-primary"
+               aria-label="Log in"
+               ng-disabled="!m.password || doesntLookLikeToken()"
                ng-click="login()">
       <i class="zmdi zmdi-arrow-right zmdi-hc-lg"></i>
     </md-button>

--- a/src/tc-renderer/ng/elements/login/login.js
+++ b/src/tc-renderer/ng/elements/login/login.js
@@ -8,27 +8,29 @@ angular.module('tc').directive('login', function(irc, openExternal) {
     restrict: 'E',
     template: template,
     link: function(scope) {
+      scope.m = {}
       scope.irc = irc;
       scope.settings = settings;
-
-      scope.login = function() {
-        var password = scope.m.password;
-        if (!password.startsWith('oauth:')) password = 'oauth:' + password;
-        settings.identity.username = scope.m.username;
-        settings.identity.password = password;
-      };
-
-      scope.generate = function() {
-        openExternal('http://gettc.xyz/password/');
-      };
-
       // These values should NOT update the settings object or
       // it will break the form's conditionals
-      scope.m = {};
       scope.m.username = settings.identity.username;
       scope.m.password = settings.identity.password;
       scope.m.haveUsername = !!settings.identity.username.length;
       scope.m.haveNoPassword = !settings.identity.password.length;
+
+      scope.login = login
+      scope.generate = () => openExternal('http://gettc.xyz/password/')
+      scope.doesntLookLikeToken = doesntLookLikeToken
+
+      function login() {
+        settings.identity.username = scope.m.username;
+        settings.identity.password = scope.m.password;
+      }
+      
+      function doesntLookLikeToken () {
+        const password = scope.m.password
+        return !!(password && !password.startsWith('oauth'))
+      }
     }
   }
 });


### PR DESCRIPTION
I suspect a lot of reports of "Disconnected" are because people try using their normal password instead of a token