### PR TITLE
Add ctrl/cmd + w as hotkey to leave channel.

### DIFF
--- a/src/tc-renderer/lib/startup/keybinds.js
+++ b/src/tc-renderer/lib/startup/keybinds.js
@@ -5,6 +5,7 @@ key.filter = () => true
 
 function registerShortcuts () {
   key('⌘+n, ctrl+n', goToAddChannel)
+  key('⌘+w, ctrl+w', leaveChannel)
   key('⌘+tab, ctrl+tab', nextTab)
   key('⌘+shift+tab, ctrl+shift+tab', previousTab)
   key('⌘+s, ctrl+s', toggleSidebar)
@@ -52,6 +53,10 @@ function previousTab () {
 
 function goToAddChannel () {
   settings.selectedTabIndex = settings.channels.length
+}
+
+function leaveChannel () {
+  settings.channels.splice(settings.selectedTabIndex, 1)
 }
 
 export default registerShortcuts


### PR DESCRIPTION
First PR, be gentle
Adds the ctrl/cmd + w hotkey to leave the current channel. It uses the same functionality that the leave button on the side-toolbar uses.

Closes #387 