### PR TITLE
Add live indicator to chat tabs

### DIFF
--- a/src/tc-renderer/ng/elements/chat-tabs/chat-tabs.css
+++ b/src/tc-renderer/ng/elements/chat-tabs/chat-tabs.css
@@ -82,12 +82,16 @@ chat-tabs md-tab-item:nth-last-of-type(2) .move-arrow.right {
   display: none;
 }
 
-chat-tabs .zmdi-circle {
+chat-tabs .zmdi-circle, chat-tabs .zmdi-replay {
   font-size: 0.65em;
   padding-right: 1px;
   position: relative;
   top: -2px;
   left: -1px;
+}
+
+chat-tabs .zmdi-replay {
+  font-size: 0.75em !important;
 }
 
 chat-tabs .live-indicator {

--- a/src/tc-renderer/ng/elements/chat-tabs/chat-tabs.css
+++ b/src/tc-renderer/ng/elements/chat-tabs/chat-tabs.css
@@ -83,10 +83,17 @@ chat-tabs md-tab-item:nth-last-of-type(2) .move-arrow.right {
 }
 
 chat-tabs .zmdi-circle {
-  color: rgba(255,0,0,0.8);
   font-size: 0.65em;
   padding-right: 1px;
   position: relative;
   top: -2px;
   left: -1px;
+}
+
+chat-tabs .live-indicator {
+  color: rgba(255,0,0,0.8);  
+}
+
+chat-tabs .rerun-indicator {
+  color: rgba(200,200,200,0.8);
 }

--- a/src/tc-renderer/ng/elements/chat-tabs/chat-tabs.css
+++ b/src/tc-renderer/ng/elements/chat-tabs/chat-tabs.css
@@ -81,3 +81,7 @@ chat-tabs md-tab-item:first-of-type .move-arrow.left {
 chat-tabs md-tab-item:nth-last-of-type(2) .move-arrow.right {
   display: none;
 }
+
+chat-tabs .zmdi-circle {
+  color: rgba(255,0,0,0.8);
+}

--- a/src/tc-renderer/ng/elements/chat-tabs/chat-tabs.css
+++ b/src/tc-renderer/ng/elements/chat-tabs/chat-tabs.css
@@ -84,4 +84,9 @@ chat-tabs md-tab-item:nth-last-of-type(2) .move-arrow.right {
 
 chat-tabs .zmdi-circle {
   color: rgba(255,0,0,0.8);
+  font-size: 0.65em;
+  padding-right: 1px;
+  position: relative;
+  top: -2px;
+  left: -1px;
 }

--- a/src/tc-renderer/ng/elements/chat-tabs/chat-tabs.html
+++ b/src/tc-renderer/ng/elements/chat-tabs/chat-tabs.html
@@ -11,8 +11,12 @@
           class="zmdi zmdi-chevron-left move-arrow left"
       ></i>
       <i
-          class="zmdi zmdi-circle"
-          ng-if="live(channel)"
+          class="zmdi zmdi-circle live-indicator"
+          ng-if="live(channel) === 'live'"
+      ></i>
+      <i
+          class="zmdi zmdi-replay rerun-indicator"
+          ng-if="live(channel) === 'rerun'"
       ></i>
       {{channel}}
       <span class="counter">{{unread(channel)}}</span>

--- a/src/tc-renderer/ng/elements/chat-tabs/chat-tabs.html
+++ b/src/tc-renderer/ng/elements/chat-tabs/chat-tabs.html
@@ -10,6 +10,10 @@
           ng-click="moveLeft($event, channel)"
           class="zmdi zmdi-chevron-left move-arrow left"
       ></i>
+      <i
+          class="zmdi zmdi-circle"
+          ng-if="live(channel)"
+      ></i>
       {{channel}}
       <span class="counter">{{unread(channel)}}</span>
       <i

--- a/src/tc-renderer/ng/elements/chat-tabs/chat-tabs.js
+++ b/src/tc-renderer/ng/elements/chat-tabs/chat-tabs.js
@@ -149,12 +149,14 @@ angular.module('tc').directive('chatTabs', ($timeout, messages) => {
     function isLive(channel) {
       try {
         // Will throw undefined when Tc first loads
-        if (scope.m.streams[channel].stream !== null) {
-          return true
+        if (scope.m.streams[channel].stream.stream_type === 'live') {
+          return 'live'
+        } else if (scope.m.streams[channel].stream.stream_type === 'rerun') {
+          return 'rerun'
         }
       }
       catch (e) {
-        return false
+        return
       }
     }
   }

--- a/src/tc-renderer/ng/elements/chat-tabs/chat-tabs.js
+++ b/src/tc-renderer/ng/elements/chat-tabs/chat-tabs.js
@@ -134,8 +134,8 @@ angular.module('tc').directive('chatTabs', ($timeout, messages) => {
     }
 
     async function getStreams() {
-      scope.m.streams = {}
       for (const channel of settings.channels) {
+        if (typeof scope.m.streams === 'undefined') { scope.m.streams = {} }
         try {
           // Will throw undefined when Tc first loads
           scope.m.streams[channel] = await api.stream(channel)


### PR DESCRIPTION
![Screenshot live-indicator](https://user-images.githubusercontent.com/19501722/38950340-71c1a3ac-4345-11e8-8f25-0084b76088f4.png)

Adds a red circle for when the stream is live. 
There's still some issues with it that I'm not sure how to address as I'm fairly new to Angular.

I followed the functionality from [thumbnail.js](https://github.com/mccxiv/tc/blob/master/src/tc-renderer/ng/elements/thumbnail/thumbnail.js) on how to get stream information and passed the streams to `scope.m.streams`. Then used `ng-if="live(channel)"` for the indicator. When Tc first loads this won't work properly so there's a few try/catch blocks to catch the undefined errors. Let me know if there's a better way to do it! (also the circle might be slightly too big, I fine it acceptable but others might not)

Related issue: #370