### PR TITLE
Add \ to escape channels on launch

### DIFF
--- a/src/tc-renderer/lib/startup/commandline.js
+++ b/src/tc-renderer/lib/startup/commandline.js
@@ -6,7 +6,7 @@ export default function joinChannelFromCommand() {
     electron.remote.process.argv.forEach(function (arg) {
         if (arg.includes('--channel=')) {
             setTimeout(function () {
-                main.webContents.send('join-channel', arg.slice(10))
+                main.webContents.send('join-channel', arg.slice(10).replace(/\\/g, ''))
             }, 1500)
         }
     })


### PR DESCRIPTION
When trying to launch a chat with the --channel=... option through Streamlink
![Streamlink --channel=...](https://user-images.githubusercontent.com/19501722/39020727-1fac44fc-442e-11e8-8a71-c5d52f4e284b.png)

I encountered this issue: ![Escaped sodapoppin string](https://user-images.githubusercontent.com/19501722/39020840-82dc6dae-442e-11e8-9219-d4aeb6513763.png)

~~This could be a Streamlink issue but it's not a big thing to fix here.~~

Edit: After looking at the variables a bit more the correct usage is described here:
![Streamlink](https://user-images.githubusercontent.com/19501722/39053461-58a7be90-44af-11e8-8b8f-fe58c02785c0.png)

I still think this PR could be useful however it's no issue to just close it too.