### PR TITLE
Add basic functionality for user highlights

### DIFF
--- a/src/tc-renderer/ng/elements/settings-panel/settings-panel.html
+++ b/src/tc-renderer/ng/elements/settings-panel/settings-panel.html
@@ -65,13 +65,14 @@
   <md-content ng-switch-when="highlights" class="highlights">
     <h1 class="md-headline">Highlighted phrases</h1>
     <p>
-      You may add words and phrases to make them stand out in chat and
+      You may add words, phrases or users to make them stand out in chat and
       show up as desktop notifications. Matches are not case sensitive.
+      Users can be added as:&nbsp;user:name.
     </p>
 
     <form class="input-form" ng-submit="highlights.add()">
       <md-input-container>
-        <label>Add a new phrase. Supports regex</label>
+        <label>Add a new phrase or user.<br>Phrases support regex, users do not</label>
         <input ng-model="highlights.input">
       </md-input-container>
     </form>

--- a/src/tc-renderer/ng/providers/highlights.js
+++ b/src/tc-renderer/ng/providers/highlights.js
@@ -14,8 +14,13 @@ angular.module('tc').factory('highlights', function () {
         if (me.test(line)) return true
       }
       return settings.highlights.some(function (highlight) {
-        const regex = new RegExp(`\\b${highlight}\\b`, 'i')
-        return regex.test(line)
+        if (highlight.startsWith('user:')) {
+          const regex = new RegExp(`\\b${highlight.substring(5, highlight.length)}\\b`, 'i')
+          return regex.test(line.substring(0, line.indexOf(':')))
+        } else {
+          const regex = new RegExp(`\\b${highlight}\\b`, 'i')
+          return regex.test(line)
+        }
       })
     },
 

--- a/src/tc-renderer/ng/providers/highlights.js
+++ b/src/tc-renderer/ng/providers/highlights.js
@@ -9,17 +9,18 @@ angular.module('tc').factory('highlights', function () {
      * @return {boolean}     - True if `line` contains a highlighted phrase.
      */
     test: function (line) {
+      const user = line.substring(0, line.indexOf(':'))
+      const message = line.substring(line.indexOf(':') + 2, line.length)
       if (settings.highlightMe) {
         const me = new RegExp(settings.identity.username, 'i')
-        if (me.test(line)) return true
+        if (me.test(message)) return true
       }
       return settings.highlights.some(function (highlight) {
         if (highlight.startsWith('user:')) {
-          const regex = new RegExp(`\\b${highlight.substring(5, highlight.length)}\\b`, 'i')
-          return regex.test(line.substring(0, line.indexOf(':')))
+          return user === highlight.toLowerCase().substring(5, highlight.length)
         } else {
           const regex = new RegExp(`\\b${highlight}\\b`, 'i')
-          return regex.test(line)
+          return regex.test(message)
         }
       })
     },

--- a/src/tc-renderer/ng/providers/highlights.js
+++ b/src/tc-renderer/ng/providers/highlights.js
@@ -5,12 +5,11 @@ angular.module('tc').factory('highlights', function () {
   return {
     /**
      * Test if a string matches any of the saved highlighted phrases.
-     * @param {string} line  - Where to search for highlights.
+     * @param {string} message  - Message to search for highlights.
+     * @param {string} user - User to search for highlights.
      * @return {boolean}     - True if `line` contains a highlighted phrase.
      */
-    test: function (line) {
-      const user = line.substring(0, line.indexOf(':'))
-      const message = line.substring(line.indexOf(':') + 2, line.length)
+    test: function (message, user) {
       if (settings.highlightMe) {
         const me = new RegExp(settings.identity.username, 'i')
         if (me.test(message)) return true

--- a/src/tc-renderer/ng/providers/messages.js
+++ b/src/tc-renderer/ng/providers/messages.js
@@ -167,8 +167,9 @@ angular.module('tc').factory('messages', (
     if (user.special) user.special.reverse()
     if (!user['display-name']) user['display-name'] = user.username
     if (isFfzDonor(user.username)) user.ffz_donor = true
-    if (highlights.test(`${user.username}: ${message}`) && notSelf) obj.highlighted = true
-
+    if (highlights.test(message, user.username) && notSelf) {
+      obj.highlighted = true
+    }
     addMessage(channel, obj)
   }
 

--- a/src/tc-renderer/ng/providers/messages.js
+++ b/src/tc-renderer/ng/providers/messages.js
@@ -167,7 +167,7 @@ angular.module('tc').factory('messages', (
     if (user.special) user.special.reverse()
     if (!user['display-name']) user['display-name'] = user.username
     if (isFfzDonor(user.username)) user.ffz_donor = true
-    if (highlights.test(message) && notSelf) obj.highlighted = true
+    if (highlights.test(`${user.username}: ${message}`) && notSelf) obj.highlighted = true
 
     addMessage(channel, obj)
   }


### PR DESCRIPTION
This adds the basis for highlighting all messages from a specified user, I'm not sure if we want to separate phrases and users entirely so for now I've kept them under the same array (`settings.highlights`).
If this were to be added I think we'd want to specify how to highlight users too in the settings panel.

Closes #388 