### PR TITLE
Add code to display linked images as images

### DIFF
--- a/src/tc-renderer/lib/transforms/add-image-urls-as-images.js
+++ b/src/tc-renderer/lib/transforms/add-image-urls-as-images.js
@@ -1,0 +1,34 @@
+// Note: Needs to come after link recognition.
+export default function addImageURLsAsImages (message) {
+  const linkFinder = /<a href="([^"]*)" target="_blank">(.*?)<\/a>/
+  let newMessage = message
+  let matchArray = linkFinder.exec(newMessage)
+  if (matchArray) {
+	let newLinkText
+	const re = /(.*(?:jpg|png|gif|jpeg))$/mg
+	let link = matchArray[1]
+	if (re.test(link)) {
+	  newLinkText = '<img src="' + link.replace('media.giphy.com',
+		'media1.giphy.com') + '" alt="' + link + '" class="inlineimg"/>'
+	}
+	let match = /^https?:\/\/giphy\.com\/gifs\/(.*-)?([a-zA-Z0-9]+)$/mg
+	  .exec(link)
+	if (match) {
+	  let imageUrl = 'https://media1.giphy.com/media/' +
+		match[2].split('-').pop() + '/giphy.gif'
+	  newLinkText = '<img src="' + imageUrl + '" alt="' + link + 
+	    '" class="inlineimg"/>'
+	}
+	match =
+	  /^https?:\/\/(www\.)?(youtu\.be\/|youtube\.com\/watch\?v=)([^&?]+).*$/mg
+		.exec(link)
+	if (match) {
+	  let imageUrl = 'https://img.youtube.com/vi/' + match[3] + '/mqdefault.jpg'
+	  newLinkText = '<br/><img src="' + imageUrl + '" alt="' + link + 
+	   '" class="inlineimg"/>'
+	}
+	newMessage = newMessage.replace(matchArray[0],
+	  `<a href="${link}" target="_blank">${newLinkText}</a>`)
+  }
+  return newMessage
+}

--- a/src/tc-renderer/lib/transforms/process-message.js
+++ b/src/tc-renderer/lib/transforms/process-message.js
@@ -1,5 +1,6 @@
 import escape from './escape'
 import addLinks from './add-links'
+import addImageURLsAsImages from './add-image-urls-as-images'
 import ffzEmotes from '../emotes/ffz'
 import bttvEmotes from '../emotes/bttv'
 import addBitGifs from './add-bit-gifs'
@@ -12,6 +13,7 @@ export default function processMessage (msgObject, channel, emotesFromTwitch) {
   let msg = msgObject.message
   msg = escape(msg)
   msg = addLinks(msg)
+  msg = addImageURLsAsImages(msg)
   msg = addEmotesAsImages(msg, bttvEmotes(channel))
   msg = addEmotesAsImages(msg, ffzEmotes(channel))
   msg = twitchE ? addEmotesAsImages(msg, twitchEmotes(original, twitchE)) : msg

--- a/src/tc-renderer/ng/elements/chat-output/chat-output.css
+++ b/src/tc-renderer/ng/elements/chat-output/chat-output.css
@@ -140,3 +140,8 @@ chat-output .variable-line-height .emoticon {
   bottom: unset;
   vertical-align: -3px;
 }
+
+chat-output .inlineimg {
+  max-width: 400px;
+  max-height: 200px;
+}


### PR DESCRIPTION
This will display (the first in a message) image linked inline (max size 400x200, CSS will auto-scale it)
It will also grab YouTube thunbnails for linked YouTube videos.
They should remain clickable, as before.

This should match the coding style the rest uses. And should be easy to make configurable if you like.