### PR TITLE
Added option to add inline mod actions #460

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6773,12 +6773,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6793,17 +6795,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6920,7 +6925,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6932,6 +6938,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6946,6 +6953,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -7057,7 +7065,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7069,6 +7078,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7190,6 +7200,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/tc-renderer/ng/components/chat-output/chat-output.js
+++ b/src/tc-renderer/ng/components/chat-output/chat-output.js
@@ -145,7 +145,6 @@ function controller($scope, $element, $sce, $timeout, messages, session, irc, op
   }
 
   function isModableChat (m) {
-    console.log(m)
     return settings.chat.modactions && m.user &&
       (!m.user.mod && !isBroadcaster(m.user.username) &&
        (m.type === 'chat' || m.type === 'action'))

--- a/src/tc-renderer/ng/components/chat-output/chat-output.js
+++ b/src/tc-renderer/ng/components/chat-output/chat-output.js
@@ -75,8 +75,6 @@ function controller($scope, $element, $sce, $timeout, messages, session, irc, op
   vm.amMod = amMod
   vm.isModableChat = isModableChat
 
-  vm.purged = {}
-
   // ===============================================================
   // Functions
   // ===============================================================

--- a/src/tc-renderer/ng/components/chat-output/chat-output.js
+++ b/src/tc-renderer/ng/components/chat-output/chat-output.js
@@ -19,7 +19,7 @@ angular.module('tc').component('chatOutput', {
 })
 
 // eslint-disable-next-line
-function controller ($scope, $element, $sce, $timeout, messages, session, openExternal, settings) {
+function controller($scope, $element, $sce, $timeout, messages, session, openExternal, settings, irc) {
   $element = $($element[0])
 
   const e = $element[0]
@@ -68,6 +68,11 @@ function controller ($scope, $element, $sce, $timeout, messages, session, openEx
   vm.messageClasses = messageClasses
   vm.messageInlineStyles = messageInlineStyles
   vm.displayNameIsDifferent = displayNameIsDifferent
+  vm.ban = ban
+  vm.timeout = timeout
+  vm.purge = purge
+  vm.amMod = amMod
+  vm.isModableChat = isModableChat
 
   // ===============================================================
   // Functions
@@ -111,6 +116,31 @@ function controller ($scope, $element, $sce, $timeout, messages, session, openEx
     const badge = getBadge(name, version)
     if (!badge) return undefined
     return badge.image_url_1x
+  }
+
+  function timeout (m, seconds) {
+    const toMsg = `.timeout ${m.user.username} ${(seconds || 600)}`
+    irc.say(m.channel, toMsg)
+  }
+
+  function purge (m) {
+    timeout(m, 3)
+  }
+
+  function ban (m) {
+    const banMsg = '.ban ' + m.user.username
+    irc.say(m.channel, banMsg)
+  }
+
+  function amMod () {
+    const channel = settings.channels[settings.selectedTabIndex]
+    return irc.isMod('#' + channel, settings.identity.username)
+  }
+
+  function isModableChat (m) {
+    return m.user &&
+      (!m.user.mod && m.user['user-id'] !== m.user['room-id'] &&
+       m.type === 'chat')
   }
 
   function getBadge (name, version) {

--- a/src/tc-renderer/ng/components/chat-output/chat-output.js
+++ b/src/tc-renderer/ng/components/chat-output/chat-output.js
@@ -138,7 +138,7 @@ function controller($scope, $element, $sce, $timeout, messages, session, openExt
   }
 
   function isModableChat (m) {
-    return m.user &&
+    return settings.chat.modactions && m.user &&
       (!m.user.mod && m.user['user-id'] !== m.user['room-id'] &&
        m.type === 'chat')
   }

--- a/src/tc-renderer/ng/components/chat-output/chat-output.pug
+++ b/src/tc-renderer/ng/components/chat-output/chat-output.pug
@@ -9,6 +9,16 @@
   )
     span.timestamp.lighter(ng-if='::vm.settings.chat.timestamps')
       | {{::m.at | date: 'H:mm'}}  
+    span.mod-actions(ng-class='{disabled: !vm.amMod()}', ng-if='::vm.isModableChat(m)')
+      md-button(ng-click='vm.purge(m)', aria-label='Purge')
+        md-tooltip(md-autohide='') Purge (3s)
+        i.zmdi.zmdi-replay-5
+      md-button(ng-click='vm.timeout(m)', aria-label='Timeout')
+        md-tooltip(md-autohide='') Timeout (10m)
+        i.zmdi.zmdi-time-restore
+      md-button(ng-click='vm.ban(m)', aria-label='Ban')
+        md-tooltip(md-autohide='') Ban
+        i.zmdi.zmdi-block
     span.badges(ng-if='::m.user')
       span.badge(
         ng-repeat='(name, version) in ::m.user.badges',

--- a/src/tc-renderer/ng/components/chat-output/chat-output.styl
+++ b/src/tc-renderer/ng/components/chat-output/chat-output.styl
@@ -60,12 +60,20 @@ chat-output
     line-height: 17px
     word-wrap: break-word
 
-  .chat-line .separator
-    margin-right: 2px
-
-  .chat-line .username
-    font-weight: bold
-
+    .separator
+      margin-right: 2px
+    .username
+      font-weight: bold
+    .mod-actions
+      margin-right: 5px
+      .md-button
+        margin: 0
+        height: 21px
+        min-width: 0
+        min-height: 0
+        padding: 0 3px
+        line-height: normal
+        border-radius: 0 !important
   .highlighted
     background-color: rgba(255, 0, 0, 0.15) !important
     /* override zebra */

--- a/src/tc-renderer/ng/components/settings-panel/settings-panel.pug
+++ b/src/tc-renderer/ng/components/settings-panel/settings-panel.pug
@@ -3,7 +3,7 @@ md-sidenav.settings-sidebar.md-sidenav-left.md-whiteframe-z2.menu(
 )
   md-list
     md-subheader.md-no-sticky Settings
-    // TODO refactor this awful repetition 
+    // TODO refactor this awful repetition
     md-list-item.menu-item(
       ng-click='m.selected = "tc"',
       ng-class='{selected: m.selected === "tc"}'
@@ -157,6 +157,8 @@ md-sidenav.settings-sidebar.md-sidenav-left.md-whiteframe-z2.menu(
       | Use dark theme
     md-switch(ng-model='settings.chat.timestamps')
       | Show time stamps
+    md-switch(ng-model='settings.chat.modactions')
+      | Show inline moderator actions
     md-switch(ng-model='settings.appearance.split')
       | Split chat lines for more contrast
     md-switch(ng-model='settings.appearance.variableLineHeight')

--- a/src/tc-renderer/store/modules/settings/default-settings.js
+++ b/src/tc-renderer/store/modules/settings/default-settings.js
@@ -5,6 +5,7 @@ export default {
   },
   chat: {
     timestamps: false,
+    modactions: true,
     ignored: []
   },
   notifications: {


### PR DESCRIPTION
- adds inline mod actions for mods
  - when the message is type: chat 
  - when the message is type: action
  - when the message is not from the broadcaster
  - when the message is not from another mod
  - when the inline mod actions is enabled in the settings

![image](https://user-images.githubusercontent.com/171452/45794176-fe0acf80-bc5a-11e8-8ec6-94836702d741.png)

![image](https://user-images.githubusercontent.com/171452/45794185-0a8f2800-bc5b-11e8-9e6f-35e4778e0413.png)

