### PR TITLE
Tweak Camalot's PR and fix bugs

### DIFF
--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -229,12 +229,6 @@
       "integrity": "sha512-LOdIGR3Ry5mPtweBk+fYyH6UmBDIuK1s7CiKG8fUxWQHmderecRUEt2/T0O1awnGIsXFiJxOvfN18XwWA/iwkw==",
       "dev": true
     },
-    "moment": {
-      "version": "2.22.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
-      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y=",
-      "dev": true
-    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",

--- a/src/package.json
+++ b/src/package.json
@@ -24,7 +24,6 @@
     "material-design-iconic-font": "2.1.2",
     "mobx": "^5.0.3",
     "mobx-angularjs": "^1.6.0",
-    "moment": "^2.21.0",
     "nprogress": "0.2.0",
     "proxy-observe": "github:mccxiv/proxy-observe",
     "ramda": "^0.25.0",

--- a/src/tc-renderer/ng/components/chat-output/chat-output.js
+++ b/src/tc-renderer/ng/components/chat-output/chat-output.js
@@ -66,7 +66,7 @@ function controller($scope, $element, $sce, $timeout, messages, session, irc, op
   vm.badgeBg = badgeBg
   vm.badgeTitle = badgeTitle
   vm.isOdd = isOdd
-  vm.messageClasses = messageClasses
+  vm.messageClassesAsString = messageClassesAsString
   vm.messageInlineStyles = messageInlineStyles
   vm.displayNameIsDifferent = displayNameIsDifferent
   vm.shortTimeout = shortTimeout
@@ -330,16 +330,19 @@ function controller($scope, $element, $sce, $timeout, messages, session, irc, op
     return color
   }
 
-  function messageClasses (m) {
-    return {
+  function messageClassesAsString (m) {
+    const classPresence = {
       'from-backlog': m.fromBacklog,
       highlighted: m.highlighted,
-      deleted: m.deleted,
       whisper: m.type === 'whisper',
       notification: m.type === 'notification',
       golden: m.golden,
       odd: m._isOdd
     }
+
+    return Object.keys(classPresence)
+      .filter(key => classPresence[key])
+      .join(' ')
   }
 
   function messageInlineStyles (m) {

--- a/src/tc-renderer/ng/components/chat-output/chat-output.js
+++ b/src/tc-renderer/ng/components/chat-output/chat-output.js
@@ -70,8 +70,8 @@ function controller($scope, $element, $sce, $timeout, messages, session, irc, op
   vm.messageInlineStyles = messageInlineStyles
   vm.displayNameIsDifferent = displayNameIsDifferent
   vm.shortTimeout = shortTimeout
-  vm.amMod = amMod
-  vm.isModableChat = isModableChat
+  vm.canModHere = canModHere
+  vm.isModableMessage = isModableMessage
 
   // ===============================================================
   // Functions
@@ -124,15 +124,18 @@ function controller($scope, $element, $sce, $timeout, messages, session, irc, op
     }
   }
 
-  function amMod () {
+  function canModHere () {
     const channel = settings.channels[settings.selectedTabIndex]
-    return irc.isMod('#' + channel, settings.identity.username)
+    return isBroadcaster(channel) ||
+      irc.isMod('#' + channel, settings.identity.username)
   }
 
-  function isModableChat (m) {
-    return settings.chat.modactions && m.user &&
-      (!m.user.mod && !isBroadcaster(m.user.username) &&
-       (m.type === 'chat' || m.type === 'action'))
+  function isModableMessage (m) {
+    return settings.chat.modactions &&
+      m.user &&
+      !m.user.mod &&
+      !isBroadcaster(m.user.username) &&
+      (m.type === 'chat' || m.type === 'action')
   }
 
   function getBadge (name, version) {

--- a/src/tc-renderer/ng/components/chat-output/chat-output.js
+++ b/src/tc-renderer/ng/components/chat-output/chat-output.js
@@ -119,15 +119,15 @@ function controller($scope, $element, $sce, $timeout, messages, session, irc, op
 
   function shortTimeout (m) {
     if (m.user) {
-      const toMsg = `.timeout ${m.user.username} 60`
+      const toMsg = `.timeout ${m.user.username} 30`
       irc.say(`#${m.channel}`, toMsg)
     }
   }
 
   function canModHere () {
     const channel = settings.channels[settings.selectedTabIndex]
-    return isBroadcaster(channel) ||
-      irc.isMod('#' + channel, settings.identity.username)
+    const myUsername = settings.identity.username
+    return isBroadcaster(myUsername) || irc.isMod(`#${channel}`, myUsername)
   }
 
   function isModableMessage (m) {

--- a/src/tc-renderer/ng/components/chat-output/chat-output.js
+++ b/src/tc-renderer/ng/components/chat-output/chat-output.js
@@ -69,9 +69,7 @@ function controller($scope, $element, $sce, $timeout, messages, session, irc, op
   vm.messageClasses = messageClasses
   vm.messageInlineStyles = messageInlineStyles
   vm.displayNameIsDifferent = displayNameIsDifferent
-  vm.ban = ban
-  vm.timeout = timeout
-  vm.purge = purge
+  vm.shortTimeout = shortTimeout
   vm.amMod = amMod
   vm.isModableChat = isModableChat
 
@@ -119,23 +117,10 @@ function controller($scope, $element, $sce, $timeout, messages, session, irc, op
     return badge.image_url_1x
   }
 
-  function timeout (m, seconds) {
+  function shortTimeout (m) {
     if (m.user) {
-      const toMsg = `.timeout ${m.user.username} ${(seconds || 600)}`
-      irc.say(m.channel, toMsg)
-      vm.messages.timeoutFromChat(m.channel, m.user.username)
-    }
-  }
-
-  function purge (m) {
-    timeout(m, 3)
-  }
-
-  function ban (m) {
-    if (m.user) {
-      const banMsg = '.ban ' + m.user.username
-      irc.say(m.channel, banMsg)
-      vm.messages.timeoutFromChat(m.channel, m.user.username)
+      const toMsg = `.timeout ${m.user.username} 60`
+      irc.say(`#${m.channel}`, toMsg)
     }
   }
 

--- a/src/tc-renderer/ng/components/chat-output/chat-output.pug
+++ b/src/tc-renderer/ng/components/chat-output/chat-output.pug
@@ -4,7 +4,7 @@
 )
   .chat-line(
     ng-repeat='m in vm.messages',
-    ng-class='::vm.messageClasses(m)',
+    class='{{m.deleted ? "deleted" : ""}} {{::vm.messageClassesAsString(m)}}',
     ng-style='::vm.messageInlineStyles(m)'
   )
     span.timestamp.lighter(ng-if='::vm.settings.chat.timestamps')

--- a/src/tc-renderer/ng/components/chat-output/chat-output.pug
+++ b/src/tc-renderer/ng/components/chat-output/chat-output.pug
@@ -9,10 +9,7 @@
   )
     span.timestamp.lighter(ng-if='::vm.settings.chat.timestamps')
       | {{::m.at | date: 'H:mm'}}  
-    span.mod-actions(
-      ng-class='{disabled: !vm.amMod()}',
-      ng-if='::vm.isModableChat(m)'
-    )
+    span.mod-actions(ng-if='::vm.canModHere() && vm.isModableMessage(m)')
       md-button(ng-click='vm.shortTimeout(m)', aria-label='Timeout')
         md-tooltip(md-autohide='') Timeout (1m)
         i.zmdi.zmdi-time-restore

--- a/src/tc-renderer/ng/components/chat-output/chat-output.pug
+++ b/src/tc-renderer/ng/components/chat-output/chat-output.pug
@@ -9,16 +9,13 @@
   )
     span.timestamp.lighter(ng-if='::vm.settings.chat.timestamps')
       | {{::m.at | date: 'H:mm'}}  
-    span.mod-actions(ng-class='{disabled: !vm.amMod()}', ng-if='::vm.isModableChat(m)')
-      md-button(ng-click='vm.purge(m)', aria-label='Purge')
-        md-tooltip(md-autohide='') Purge (3s)
-        i.zmdi.zmdi-replay-5
-      md-button(ng-click='vm.timeout(m)', aria-label='Timeout')
-        md-tooltip(md-autohide='') Timeout (10m)
+    span.mod-actions(
+      ng-class='{disabled: !vm.amMod()}',
+      ng-if='::vm.isModableChat(m)'
+    )
+      md-button(ng-click='vm.shortTimeout(m)', aria-label='Timeout')
+        md-tooltip(md-autohide='') Timeout (1m)
         i.zmdi.zmdi-time-restore
-      md-button(ng-click='vm.ban(m)', aria-label='Ban')
-        md-tooltip(md-autohide='') Ban
-        i.zmdi.zmdi-block
     span.badges(ng-if='::m.user')
       span.badge(
         ng-repeat='(name, version) in ::m.user.badges',

--- a/src/tc-renderer/ng/components/chat-output/chat-output.pug
+++ b/src/tc-renderer/ng/components/chat-output/chat-output.pug
@@ -11,7 +11,7 @@
       | {{::m.at | date: 'H:mm'}}  
     span.mod-actions(ng-if='::vm.canModHere() && vm.isModableMessage(m)')
       md-button(ng-click='vm.shortTimeout(m)', aria-label='Timeout')
-        md-tooltip(md-autohide='') Timeout (1m)
+        md-tooltip(md-autohide='') Purge (30s)
         i.zmdi.zmdi-time-restore
     span.badges(ng-if='::m.user')
       span.badge(

--- a/src/tc-renderer/ng/providers/messages.js
+++ b/src/tc-renderer/ng/providers/messages.js
@@ -1,7 +1,6 @@
 import throttle from 'lodash.throttle'
 import angular from 'angular'
 import axios from 'axios'
-import moment from 'moment'
 import electron from 'electron'
 import channels from '../../lib/channels'
 import processMessage from '../../lib/transforms/process-message'

--- a/src/tc-renderer/ng/providers/messages.js
+++ b/src/tc-renderer/ng/providers/messages.js
@@ -353,10 +353,13 @@ angular.module('tc').factory('messages', (
         addNotification(channel, message, true)
       },
 
-      notice: (channel = '', msgId, message) => {
-        channel = channel.substr(1)
-        if (!channel || channel === '*') addGlobalNotification(message)
-        else addNotification(channel, message)
+      notice: (channel, msgId, message) => {
+        if (!channel || channel === '*' || channel === '#undefined') {
+          addGlobalNotification(message)
+        } else {
+          channel = channel.substr(1)
+          addNotification(channel, message)
+        }
       }
     }
   }

--- a/src/tc-renderer/ng/providers/messages.js
+++ b/src/tc-renderer/ng/providers/messages.js
@@ -310,15 +310,8 @@ angular.module('tc').factory('messages', (
           addNotification(channel, msg)
         }
       },
-      timeout: (channel, username, reason, duration) => {
+      timeout: (channel, username) => {
         timeoutFromChat(channel, username)
-        if (!settings.appearance.hideTimeouts) {
-          duration = Number(duration)
-          const humanDur = moment.duration(duration, 'seconds').humanize()
-          const baseMsg = username + ` has been timed out for ${humanDur}.`
-          const msg = baseMsg + (reason ? ` Reason: ${reason}.` : '')
-          addNotification(channel, msg)
-        }
       },
       clearchat: (channel) => {
         const msg = 'Chat cleared by a moderator. (Prevented by Tc)'


### PR DESCRIPTION
The significant change I made, besides bug fixes, has been to change the UI to only show 1 button. A half way between purge and timeout (30 s purge).

I think this gives people the most useful tool without cluttering the UI with too many icons. You can use it to quickly remove people from chat, and then if you truly deem it necessary, you can actually ban while they're timed out.

An improvement would be to actually show an inline ban button if someone has already been timed out, replacing the purge button.

Another improvement would be to pause chat scrolling when hovering these inline icons, to prevent accidentally purging the wrong person.

See https://github.com/mccxiv/tc/issues/463
